### PR TITLE
Resolve config from more sources

### DIFF
--- a/.changeset/polite-cups-chew.md
+++ b/.changeset/polite-cups-chew.md
@@ -1,0 +1,5 @@
+---
+'@fransvilhelm/wp-bundler': minor
+---
+
+Add ability to configure wp-bundler with .wp-bundlerrc or wp-bundler.config.json

--- a/README.md
+++ b/README.md
@@ -50,27 +50,27 @@ Then configure the scripts in your `package.json`.
 
 ## Configuration
 
-All configuration related to `wp-bundler` resides in your projects `package.json`, under the key `wp-bundler`. Below is an example configuration with all available configuration options used:
+There are _three_ places in which you can configure `wp-bundler`. Either in your projects `package.json` under the property `"wp-bundler"`, or in any of the files `.wp-bundlerrc` and `wp-bundler.config.json`.
+
+Below is an example configuration with all available configuration options used:
 
 ```json
 {
-  "wp-bundler": {
-    "entryPoints": {
-      "app": "src/app.ts",
-      "admin": "src/admin.ts"
-    },
-    "outdir": "dist",
-    "sourcemap": true,
-    "externals": { "lodash": "_" },
-    "assetLoader": {
-      "path": "inc/AssetLoader.php",
-      "namespace": "MyNamespace"
-    },
-    "translations": {
-      "domain": "theme-domain",
-      "pot": "languages/theme.pot",
-      "pos": ["languages/sv_SE.po", "languages/en_US.po"]
-    }
+  "entryPoints": {
+    "app": "src/app.ts",
+    "admin": "src/admin.ts"
+  },
+  "outdir": "dist",
+  "sourcemap": true,
+  "externals": { "lodash": "_" },
+  "assetLoader": {
+    "path": "inc/AssetLoader.php",
+    "namespace": "MyNamespace"
+  },
+  "translations": {
+    "domain": "theme-domain",
+    "pot": "languages/theme.pot",
+    "pos": ["languages/sv_SE.po", "languages/en_US.po"]
   }
 }
 ```
@@ -227,7 +227,7 @@ The `.po` files, configured in `translations.pos`, will then be used to emit `je
 
 ### PHP and Twig translations
 
-The bundler will also look for, and extract, translations from your projects `.php` and `.twig` files. It will find all of these files in you project, but ignoring the `vendor` and `node_modules` folders. This means that using this package means you are no longer need to use `wp-cli i18n make-pot/make-json` to extract and generate translations.
+The bundler will also look for, and extract, translations from your projects `.php` and `.twig` files. It will find all of these files in you project, but ignoring the `vendor` and `node_modules` folders. This means that using this package means you no longer need to use `wp-cli i18n make-pot/make-json` to extract and generate translations.
 
 `.mo` files will also me compiled from all your `.po` files.
 

--- a/src/schema.ts
+++ b/src/schema.ts
@@ -1,25 +1,29 @@
 import * as z from 'zod';
 
-export const BundlerConfigSchema = z.object({
-  entryPoints: z.record(z.string()),
-  outdir: z.string().default('./dist'),
-  sourcemap: z.boolean().optional(),
-  externals: z.record(z.string()).optional(),
-  assetLoader: z
-    .object({
-      path: z.string().default('./AssetLoader.php'),
-      namespace: z.string().default('WPBundler'),
-    })
-    .default({}),
-  translations: z
-    .object({
-      domain: z.string(),
-      pot: z.string(),
-      pos: z.array(z.string()).optional(),
-      ignore: z.array(z.string()).optional(),
-    })
-    .optional(),
-});
+export const BundlerConfigSchema = z
+  .object({
+    entryPoints: z.record(z.string()),
+    outdir: z.string().default('./dist'),
+    sourcemap: z.boolean().optional(),
+    externals: z.record(z.string()).optional(),
+    assetLoader: z
+      .object({
+        path: z.string().default('./AssetLoader.php'),
+        namespace: z.string().default('WPBundler'),
+      })
+      .strict()
+      .default({}),
+    translations: z
+      .object({
+        domain: z.string(),
+        pot: z.string(),
+        pos: z.array(z.string()).optional(),
+        ignore: z.array(z.string()).optional(),
+      })
+      .strict()
+      .optional(),
+  })
+  .strict();
 
 export type BundlerConfig = z.infer<typeof BundlerConfigSchema>;
 

--- a/src/utils/read-json.ts
+++ b/src/utils/read-json.ts
@@ -1,6 +1,6 @@
 import * as fs from 'fs/promises';
 
-export async function readJson(path: string) {
+export async function readJson<T = unknown>(path: string): Promise<T> {
   let raw = await fs.readFile(path, 'utf-8');
   let json = JSON.parse(raw);
   return json;

--- a/src/utils/read-json.ts
+++ b/src/utils/read-json.ts
@@ -1,0 +1,7 @@
+import * as fs from 'fs/promises';
+
+export async function readJson(path: string) {
+  let raw = await fs.readFile(path, 'utf-8');
+  let json = JSON.parse(raw);
+  return json;
+}

--- a/src/utils/read-pkg.ts
+++ b/src/utils/read-pkg.ts
@@ -1,8 +1,10 @@
 import * as fs from 'fs/promises';
 import * as path from 'path';
 import { PackageJson } from 'type-fest';
-import { BundlerConfig, BundlerConfigSchema } from '../schema';
+import { BundlerConfig } from '../schema';
 import { ProjectPaths, ProjectInfo } from '../types';
+import { readJson } from './read-json';
+import { resolveConfig } from './resolve-config';
 
 interface Metadata {
   bundler: ProjectInfo;
@@ -17,7 +19,7 @@ export async function getMetadata(projectPath: string, bundlerPath: string): Pro
   if (cached != null) return cached;
 
   let [project, bundler] = await Promise.all([readPkg(projectPath), readPkg(bundlerPath)]);
-  let config = await BundlerConfigSchema.parseAsync(project.packageJson['wp-bundler']);
+  let config = await resolveConfig(project);
 
   let metadata = { bundler, project, config };
   metadataCache.set(projectPath, metadata);
@@ -45,8 +47,7 @@ export async function readPkgUp(cwd: string = process.cwd()): Promise<ReadResult
   for (let item of items) {
     if (item === 'package.json') {
       let pkgPath = path.join(cwd, item);
-      let raw = await fs.readFile(pkgPath, 'utf-8');
-      let packageJson = JSON.parse(raw);
+      let packageJson = await readJson(pkgPath);
 
       return { path: pkgPath, packageJson };
     }

--- a/src/utils/read-pkg.ts
+++ b/src/utils/read-pkg.ts
@@ -47,7 +47,7 @@ export async function readPkgUp(cwd: string = process.cwd()): Promise<ReadResult
   for (let item of items) {
     if (item === 'package.json') {
       let pkgPath = path.join(cwd, item);
-      let packageJson = await readJson(pkgPath);
+      let packageJson = await readJson<ProjectInfo['packageJson']>(pkgPath);
 
       return { path: pkgPath, packageJson };
     }
@@ -56,7 +56,7 @@ export async function readPkgUp(cwd: string = process.cwd()): Promise<ReadResult
   return readPkgUp(path.dirname(cwd));
 }
 
-function createPaths(pkgPath: string): ProjectPaths {
+export function createPaths(pkgPath: string): ProjectPaths {
   let root = path.dirname(pkgPath);
   return {
     root,

--- a/src/utils/resolve-config.test.ts
+++ b/src/utils/resolve-config.test.ts
@@ -1,0 +1,110 @@
+import { ProjectInfo } from '../types';
+import { createPaths } from './read-pkg';
+import { _resolveConfig } from './resolve-config';
+import merge from 'lodash.merge';
+
+const readJson = jest.fn<Promise<unknown>, [string]>();
+const resolveConfig = (project: ProjectInfo) => _resolveConfig(project, readJson);
+
+beforeEach(() => {
+  jest.resetAllMocks();
+});
+
+describe('resolveConfig()', () => {
+  it('resolves configuration from package.json', async () => {
+    let project = createPackageInfo({ packageJson: { 'wp-bundler': { entryPoints: { entry: './src/index.ts' } } } });
+    let configuration = await resolveConfig(project);
+    expect(configuration).toHaveProperty('entryPoints', { entry: './src/index.ts' });
+  });
+
+  it('resolves configuration from .wp-bundlerrc', async () => {
+    readJson.mockImplementation((path) => {
+      if (path === '/project/.wp-bundlerrc') {
+        return Promise.resolve({ entryPoints: { entry: './src/index.ts' } });
+      } else {
+        return Promise.resolve(undefined);
+      }
+    });
+
+    let project = createPackageInfo({ packageJson: {} });
+    let configuration = await resolveConfig(project);
+    expect(configuration).toHaveProperty('entryPoints', { entry: './src/index.ts' });
+  });
+
+  it('resolves configuration from wp-bundler.config.json', async () => {
+    readJson.mockImplementation((path) => {
+      if (path === '/project/wp-bundler.config.json') {
+        return Promise.resolve({ entryPoints: { entry: './src/index.ts' } });
+      } else {
+        return Promise.resolve(undefined);
+      }
+    });
+
+    let project = createPackageInfo({ packageJson: {} });
+    let configuration = await resolveConfig(project);
+    expect(configuration).toHaveProperty('entryPoints', { entry: './src/index.ts' });
+  });
+
+  it('will log a warning if more than one way of config is found', async () => {
+    readJson.mockImplementation((path) => {
+      if (path === '/project/.wp-bundlerrc') {
+        return Promise.resolve({ entryPoints: { entry: './src/index.ts' } });
+      } else {
+        return Promise.resolve(undefined);
+      }
+    });
+
+    let spy = jest.spyOn(console, 'warn').mockImplementation();
+
+    let project = createPackageInfo({ packageJson: { 'wp-bundler': { entryPoints: { entry: './src/index.ts' } } } });
+    await resolveConfig(project);
+
+    expect(spy).toHaveBeenCalled();
+    expect(spy.mock.calls[0][0]).toMatchInlineSnapshot(
+      `"Found more than one wp-bundler configuration (package.json, .wp-bundlerrc). It is recommended to only stick with one of the options: package.json[\\"wp-bundler\\"], .wp-bundlerrc or wp-bundler.config.json."`,
+    );
+  });
+
+  it('will throw an error if no proper configuration was found', async () => {
+    let project = createPackageInfo({ packageJson: {} });
+    await expect(() => resolveConfig(project)).rejects.toThrowErrorMatchingInlineSnapshot(
+      `"Could not resolve a configuration file. Either configure wp-bundler in your package.json, in .wp-bundlerrc or in wp-bundler.config.json."`,
+    );
+  });
+
+  it('will throw an error if the resolved configuration does not match the expected schema', async () => {
+    let spy = jest.spyOn(console, 'error').mockImplementation();
+
+    let project = createPackageInfo({ packageJson: { 'wp-bundler': { entryPoints: { entry: 1 } } } });
+    await expect(() => resolveConfig(project)).rejects.toThrowErrorMatchingInlineSnapshot(
+      `"Something is wrong in your configuration file."`,
+    );
+
+    expect(spy).toHaveBeenCalled();
+    expect(spy.mock.calls[0][0]).toMatchInlineSnapshot(`
+      "[
+        {
+          \\"code\\": \\"invalid_type\\",
+          \\"expected\\": \\"string\\",
+          \\"received\\": \\"number\\",
+          \\"path\\": [
+            \\"entryPoints\\",
+            \\"entry\\"
+          ],
+          \\"message\\": \\"Expected string, received number\\"
+        }
+      ]"
+    `);
+  });
+});
+
+function createPackageInfo(override: Partial<ProjectInfo> = {}): ProjectInfo {
+  return merge(
+    {
+      packageJson: {},
+      path: '/project/package.json',
+      paths: createPaths('/project/package.json'),
+    },
+    override,
+  );
+}

--- a/src/utils/resolve-config.ts
+++ b/src/utils/resolve-config.ts
@@ -1,0 +1,48 @@
+import { BundlerConfig, BundlerConfigSchema } from '../schema';
+import { ProjectInfo } from '../types';
+import { readJson } from './read-json';
+
+type ConfigKey = 'package.json' | '.wp-bundlerrc' | 'wp-bundler.config.json';
+
+export async function resolveConfig(project: ProjectInfo): Promise<BundlerConfig> {
+  let configs: Record<ConfigKey, unknown> = {
+    'package.json': project.packageJson['wp-bundler'],
+    '.wp-bundlerrc': await readConfigFile(project.paths.absolute('.wp-bundlerrc')),
+    'wp-bundler.config.json': await readConfigFile(project.paths.absolute('wp-bundler.config.json')),
+  };
+
+  let foundKeys = Object.keys(configs).filter((key) => configs[key as ConfigKey] != null);
+
+  if (foundKeys.length > 1) {
+    console.warn(
+      `Found more than one wp-bundler configuration (${foundKeys.join(', ')}). ` +
+        'It is recommended to only stick with one of the options: ' +
+        'package.json["wp-bundler"], .wp-bundlerrc or wp-bundler.config.json.',
+    );
+  }
+
+  let config = configs['package.json'] ?? configs['.wp-bundlerrc'] ?? configs['wp-bundler.config.json'];
+  if (config == null) {
+    throw new Error(
+      'Could not resolve a configuration file. ' +
+        'Either configure wp-bundler in your package.json, in .wp-bundlerrc or in wp-bundler.config.json.',
+    );
+  }
+
+  let parsedConfig = BundlerConfigSchema.safeParse(config);
+  if (parsedConfig.success) {
+    return parsedConfig.data;
+  }
+
+  console.error(parsedConfig.error.toString());
+  throw new Error('Something is wrong in your configuration file.');
+}
+
+async function readConfigFile(path: string): Promise<BundlerConfig | undefined> {
+  try {
+    let json = await readJson(path);
+    return json;
+  } catch (error) {
+    return undefined;
+  }
+}


### PR DESCRIPTION
This PR gives `wp-bundler` the ability to resolve configuration from more sources than just your projects `package.json`.

From now on it will also resolve configuration from `.wp-bundlerrc` or `wp-bundler.config.json`.
