### PR TITLE
Remove unused comment when message is used again

### DIFF
--- a/.changeset/giant-needles-compete.md
+++ b/.changeset/giant-needles-compete.md
@@ -1,0 +1,5 @@
+---
+'@fransvilhelm/wp-bundler': patch
+---
+
+Remove unused comment when translation is used again

--- a/src/utils/po.test.ts
+++ b/src/utils/po.test.ts
@@ -279,6 +279,44 @@ it('handles translations that exists as single but get appended as plural', asyn
   `);
 });
 
+it('removes removed comment if translation is brought back', async () => {
+  let po = new Po(
+    `
+  msgid ""
+  msgstr ""
+  "Plural-Forms: nplurals=2; plural=(n != 1);\n"
+  "Content-Type: text/plain; charset=UTF-8\n"
+  "Content-Transfer-Encoding: 8bit\n"
+  "MIME-Version: 1.0\n"
+  "Language: en_US\n"
+
+  # THIS TRANSLATION IS NO LONGER REFERENCED INSIDE YOUR PROJECT
+  msgid "test"
+  msgstr "test"
+  `,
+    'test.po',
+  );
+
+  let pot = await Po.load('test.pot');
+
+  pot.set({ text: 'test', location: createLocation() });
+  po.updateFromTemplate(pot);
+
+  expect(po.toString()).toMatchInlineSnapshot(`
+    "msgid \\"\\"
+    msgstr \\"\\"
+    \\"Plural-Forms: nplurals=2; plural=(n != 1);\\\\n\\"
+    \\"Content-Type: text/plain; charset=utf-8\\\\n\\"
+    \\"Content-Transfer-Encoding: 8bit\\\\n\\"
+    \\"MIME-Version: 1.0\\\\n\\"
+    \\"Language: en_US\\\\n\\"
+
+    #: test.ts:1
+    msgid \\"test\\"
+    msgstr \\"test\\""
+  `);
+});
+
 function createLocation(replace: Partial<Location> = {}): Location {
   return {
     file: 'test.ts',

--- a/src/utils/po.ts
+++ b/src/utils/po.ts
@@ -114,11 +114,20 @@ export class Po {
 
         if (keysToMerge.includes(key) && typeof value === 'string' && typeof srcValue === 'string') {
           let lines = [...value.trim().split('\n'), ...srcValue.trim().split('\n')];
-          return lines
+
+          let out = lines
+            // Keep only lines with content, and uniq
             .filter((line, i, self) => !!line && self.indexOf(line) === i)
+            // Remove unused comment if translation is back in the game
+            .filter((line) => {
+              if (srcValue.includes(Po.UNUSED_COMMENT)) return true;
+              return !line.includes(Po.UNUSED_COMMENT);
+            })
             .sort()
             .join('\n')
             .replace(/translators:/gi, 'translators:');
+
+          return out;
         }
 
         if (key === 'msgstr' && Array.isArray(value) && Array.isArray(srcValue)) {


### PR DESCRIPTION
Previously the "unused" comment was kept even if a translation was
"brought" back into the game again. This change fixes that by removing
the comment if the translation is actually used again.

Fixes #28 