### PR TITLE
Make changes major instead of minor

### DIFF
--- a/.changeset/eight-snails-hope.md
+++ b/.changeset/eight-snails-hope.md
@@ -1,5 +1,5 @@
 ---
-'@fransvilhelm/wp-bundler': minor
+'@fransvilhelm/wp-bundler': major
 ---
 
 Require minimum node version 14

--- a/.changeset/nasty-mice-check.md
+++ b/.changeset/nasty-mice-check.md
@@ -1,5 +1,5 @@
 ---
-'@fransvilhelm/wp-bundler': minor
+'@fransvilhelm/wp-bundler': major
 ---
 
 Rework cli output

--- a/.changeset/new-maps-destroy.md
+++ b/.changeset/new-maps-destroy.md
@@ -1,5 +1,5 @@
 ---
-'@fransvilhelm/wp-bundler': minor
+'@fransvilhelm/wp-bundler': major
 ---
 
 Introduce build & dev sub commands


### PR DESCRIPTION
Some changesets where marked as minor when they should've been marked as major instead. This PR fixes that.

This means that next release will be major instead of minor.